### PR TITLE
killing process shouldn't raise exit event

### DIFF
--- a/lib/child-pool.js
+++ b/lib/child-pool.js
@@ -93,6 +93,7 @@ exports.prototype.send = function(message, callback) {
 
         // Kill the worker as we don't know what state it might be in
         if (msg.fatal) {
+          worker.process.removeAllListeners('exit');
           worker.process.kill();
           self.workers = _.without(self.workers, worker);
         }


### PR DESCRIPTION
This was an oversight in my last pull request #5. If you call worker.fatal that shouldn't also cause the unexpected exit to fire.
